### PR TITLE
Add instruction to build CentOS image on GCP

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,21 @@
+# Build customized CentOS VM image on Cloud
+
+## GCP
+
+1. Install Packer
+
+```shell
+brew install packer
+```
+
+2. Configure GCP credentials
+
+```shell
+gcloud auth application-default login
+```
+
+3. Build CentOS image on GCP
+
+``` shell
+packer build -var 'project=xxxx' gcp-centos.json
+```

--- a/packer/README.md
+++ b/packer/README.md
@@ -17,5 +17,5 @@ gcloud auth application-default login
 3. Build CentOS image on GCP
 
 ``` shell
-packer build -var 'project=xxxx' gcp-centos.json
+packer build -var 'project=xxxx' -var 'tag=v20201030' -var 'location=us' gcp-centos.json
 ```

--- a/packer/README.md
+++ b/packer/README.md
@@ -17,5 +17,5 @@ gcloud auth application-default login
 3. Build CentOS image on GCP
 
 ``` shell
-packer build -var 'project=xxxx' -var 'tag=v20201030' -var 'location=us' gcp-centos.json
+packer build -var 'project=xxxx' -var 'tag=v20201030' gcp-centos.json
 ```

--- a/packer/gcp-centos.json
+++ b/packer/gcp-centos.json
@@ -1,32 +1,33 @@
 {
-  "variables": {
-    "project": "",
-    "location": "us"
-  },
-  "builders": [
-    {
-      "type": "googlecompute",
-      "project_id": "{{user `project`}}",
-      "source_image": "centos-7-v20201014",
-      "ssh_username": "packer",
-      "zone": "us-central1-a",
-      "image_name": "centos-7-{{timestamp}}",
-      "image_description": "centos image with docker and cloud-init pre-installed",
-      "image_storage_locations": [
-        "{{user `location`}}"
-      ]
-    }
-  ],
-  "provisioners": [
-    {
-      "type": "shell",
-      "inline": [
-        "sudo yum update -y",
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
-        "sudo yum install -yy iptables docker-ce docker-ce-cli containerd.io socat nfs-utils logrotate jq wget cloud-init",
-        "sudo systemctl enable cloud-init"
-      ]
-    }
-  ]
+    "variables": {
+        "project": "",
+        "tag": "",
+        "location": ""
+    },
+    "builders": [
+        {
+            "type": "googlecompute",
+            "project_id": "{{user `project`}}",
+            "source_image": "centos-7-v20201014",
+            "ssh_username": "packer",
+            "zone": "us-central1-a",
+            "image_name": "centos-7-{{user `tag`}}-{{user `location`}}",
+            "image_description": "centos image with docker and cloud-init pre-installed",
+            "image_storage_locations": [
+                "{{user `location`}}"
+            ]
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [
+                "sudo yum update -y",
+                "sudo yum install -y yum-utils",
+                "sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
+                "sudo yum install -yy iptables docker-ce docker-ce-cli containerd.io socat nfs-utils logrotate jq wget cloud-init",
+                "sudo systemctl enable cloud-init"
+            ]
+        }
+    ]
 }

--- a/packer/gcp-centos.json
+++ b/packer/gcp-centos.json
@@ -1,8 +1,7 @@
 {
     "variables": {
         "project": "",
-        "tag": "",
-        "location": ""
+        "tag": ""
     },
     "builders": [
         {
@@ -11,10 +10,10 @@
             "source_image": "centos-7-v20201014",
             "ssh_username": "packer",
             "zone": "us-central1-a",
-            "image_name": "centos-7-{{user `tag`}}-{{user `location`}}",
+            "image_name": "centos-7-{{user `tag`}}",
             "image_description": "centos image with docker and cloud-init pre-installed",
             "image_storage_locations": [
-                "{{user `location`}}"
+                "us"
             ]
         }
     ],

--- a/packer/gcp-centos.json
+++ b/packer/gcp-centos.json
@@ -1,0 +1,32 @@
+{
+  "variables": {
+    "project": "",
+    "location": "us"
+  },
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "{{user `project`}}",
+      "source_image": "centos-7-v20201014",
+      "ssh_username": "packer",
+      "zone": "us-central1-a",
+      "image_name": "centos-7-{{timestamp}}",
+      "image_description": "centos image with docker and cloud-init pre-installed",
+      "image_storage_locations": [
+        "{{user `location`}}"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "sudo yum update -y",
+        "sudo yum install -y yum-utils",
+        "sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
+        "sudo yum install -yy iptables docker-ce docker-ce-cli containerd.io socat nfs-utils logrotate jq wget cloud-init",
+        "sudo systemctl enable cloud-init"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The default CentOS image on GCP does not support cloud-init which is required by Gardener. So this PR builds a customized CentOS to include cloud-init. And to speed up shoot node startup time, it also pre-installed some packages.