### PR TITLE
CentOS image add mdadm 

### DIFF
--- a/packer/gcp-centos.json
+++ b/packer/gcp-centos.json
@@ -7,7 +7,7 @@
         {
             "type": "googlecompute",
             "project_id": "{{user `project`}}",
-            "source_image": "centos-7-v20201014",
+            "source_image": "centos-7-v20201030",
             "ssh_username": "packer",
             "zone": "us-central1-a",
             "image_name": "centos-7-{{user `tag`}}",
@@ -24,7 +24,7 @@
                 "sudo yum update -y",
                 "sudo yum install -y yum-utils",
                 "sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
-                "sudo yum install -yy iptables docker-ce docker-ce-cli containerd.io socat nfs-utils logrotate jq wget cloud-init",
+                "sudo yum install -yy iptables docker-ce docker-ce-cli containerd.io socat nfs-utils logrotate jq wget cloud-init mdadm",
                 "sudo systemctl enable cloud-init"
             ]
         }


### PR DESCRIPTION
For gcp instance, we use mdadm to create a RAID 0 array. 